### PR TITLE
Enable usage inside Electron

### DIFF
--- a/src/DIDWallet.js
+++ b/src/DIDWallet.js
@@ -40,7 +40,7 @@ class DIDWallet {
       throw new Error("Cannot lock an empty wallet.");
     }
     const plaintext = JSON.stringify(this.keys);
-    let encrypt = crypto.createCipher("aes256", key);
+    let encrypt = crypto.createCipher("aes-256-cbc", key);
     let encrypted = encrypt.update(plaintext, "utf8", "hex");
     encrypted += encrypt.final("hex");
     this.ciphered = base64url.encode(Buffer.from(encrypted, "hex"));
@@ -83,7 +83,7 @@ class DIDWallet {
 
   unlock(password) {
     let key = password;
-    let decrypt = crypto.createDecipher("aes256", key);
+    let decrypt = crypto.createDecipher("aes-256-cbc", key);
     const ciphertext = base64url.toBuffer(this.ciphered).toString("hex");
     let decrypted = decrypt.update(ciphertext, "hex", "utf8");
     decrypted += decrypt.final();


### PR DESCRIPTION
Electron [uses BoringSSL as a (pragmatic) replacement for OpenSSL](https://github.com/electron/electron/issues/16195#issuecomment-450990183).

A consequence is that `crypto` has a different set of ciphers inside Electron compared to Node. In particular, the alias `aes256` is missing, but the cipher is there under the full name `aes-256-cbc`.

This tiny change makes did-wallet work inside Electron.